### PR TITLE
Remove Spotify from search prefixes

### DIFF
--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -12,8 +12,7 @@ pub const HYDROGEN_EMPTY_CHAT_TIMEOUT: u64 = 10;
 pub const HYDROGEN_QUEUE_LIMIT: usize = 1000;
 
 /// The search prefixes for the music.
-pub static HYDROGEN_SEARCH_PREFIXES: [&str; 4] =
-    ["spsearch:", "ytsearch:", "dzsearch:", "scsearch:"];
+pub static HYDROGEN_SEARCH_PREFIXES: [&str; 3] = ["ytsearch:", "dzsearch:", "scsearch:"];
 
 /// Connection timeout for the Lavalink node in seconds.
 pub const LAVALINK_RECONNECTION_DELAY: u64 = 5;


### PR DESCRIPTION
Spotify sometimes gives wrong results for searches, so this PR removes Spotify (the first prefix tried by Hydrogen) making YouTube be the first search prefix used by Hydrogen.